### PR TITLE
refactor: code quality cleanup

### DIFF
--- a/internal/game/storage.go
+++ b/internal/game/storage.go
@@ -66,7 +66,7 @@ func GetPB(duration int, mode string) float64 {
 					}
 				}
 			} else {
-				// old format fallback
+				// TODO: remove old format fallback once no users have pre-mode pb.txt files
 				dur, _ := strconv.Atoi(key)
 				if dur == duration && mode == "words" {
 					return val

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -177,7 +177,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				return m, nil
 			case "down", "j", "right", "l":
-				if m.durCur < 4 { // 0, 15, 30, 60, 120
+				if m.durCur < len(durations)-1 {
 					m.durCur++
 				}
 				return m, nil

--- a/internal/tui/profile.go
+++ b/internal/tui/profile.go
@@ -94,35 +94,26 @@ func loadProfile() profileData {
 		}
 	}
 
-	if len(wordsTests) >= 10 {
-		sum := 0.0
-		for i := len(wordsTests) - 10; i < len(wordsTests); i++ {
-			sum += wordsTests[i].WPM
-		}
-		pd.RecentAvg = sum / 10.0
-	} else if len(wordsTests) > 0 {
-		sum := 0.0
-		for _, e := range wordsTests {
-			sum += e.WPM
-		}
-		pd.RecentAvg = sum / float64(len(wordsTests))
-	}
-
-	if len(codeTests) >= 10 {
-		sum := 0.0
-		for i := len(codeTests) - 10; i < len(codeTests); i++ {
-			sum += codeTests[i].WPM
-		}
-		pd.RecentCodeAvg = sum / 10.0
-	} else if len(codeTests) > 0 {
-		sum := 0.0
-		for _, e := range codeTests {
-			sum += e.WPM
-		}
-		pd.RecentCodeAvg = sum / float64(len(codeTests))
-	}
+	pd.RecentAvg = avgWPM(wordsTests)
+	pd.RecentCodeAvg = avgWPM(codeTests)
 
 	return pd
+}
+
+// avgWPM returns the average WPM of the last 10 tests (or fewer if < 10 exist).
+func avgWPM(tests []testEntry) float64 {
+	if len(tests) == 0 {
+		return 0
+	}
+	n := 10
+	if len(tests) < n {
+		n = len(tests)
+	}
+	sum := 0.0
+	for i := len(tests) - n; i < len(tests); i++ {
+		sum += tests[i].WPM
+	}
+	return sum / float64(n)
 }
 
 func parseResultLine(line string) (testEntry, bool) {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -1,8 +1,0 @@
-package tui
-
-import "github.com/charmbracelet/lipgloss"
-
-// col renders text in a fixed-width column, handling ANSI escape codes correctly.
-func col(w int, s string) string {
-	return lipgloss.NewStyle().Width(w).Render(s)
-}

--- a/internal/tui/text.go
+++ b/internal/tui/text.go
@@ -105,3 +105,8 @@ func cursorLine(lines []string, inputLen int) int {
 	}
 	return max(0, len(lines)-1)
 }
+
+// col renders text in a fixed-width column, handling ANSI escape codes correctly.
+func col(w int, s string) string {
+	return lipgloss.NewStyle().Width(w).Render(s)
+}


### PR DESCRIPTION
- replace magic number 4 with `len(durations)-1` in duration picker
- extract `avgWPM()` helper to deduplicate WPM averaging logic
- merge styles.go into text.go (col helper was the only function)
- add TODO for legacy pb.txt format fallback removal