### PR TITLE
add 3s warm-up before showing live WPM, add AGENTS.md, update README …

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+# AGENTS.md
+
+Project context for AI coding assistants working on this repository.
+
+## Overview
+
+Toofan is a terminal typing test written in Go. It uses Bubble Tea for the TUI and Lipgloss for styling. Everything runs offline — words, code snippets, themes, and user data are all local.
+
+## Build & Run
+
+```sh
+go build -o toofan .   # compile binary
+go run .               # run without building
+go vet ./...           # lint check before committing
+```
+
+There are no external services, databases, or network calls. User data lives in `~/.toofan/` as plain text files.
+
+## Project Structure
+
+```
+main.go                         Entry point. Initializes Bubble Tea program.
+internal/
+  game/
+    game.go                     Core game logic: typing, backspace, stats, timer.
+    storage.go                  All file I/O: config, results, PBs, backups.
+  tui/
+    model.go                    Bubble Tea model, Update loop, View dispatch.
+    typing.go                   Typing screen: input handling, live WPM, progress bar.
+    results.go                  Post-test results screen.
+    profile.go                  Profile dashboard: overview, PBs, ranks, history, heatmap.
+    text.go                     Text rendering: syntax coloring, word wrapping, cursor.
+    picker.go                   Picker overlays: language, lesson, theme, duration.
+  lang/
+    lang.go                     Loads embedded word lists and code snippets from data/.
+    data/<language>/            One directory per language.
+      words.txt                 Word list (one word per line, english only).
+      lessons/<topic>.go        Code lessons (hand-written, not generated).
+  theme/
+    theme.go                    Palette struct, All slice, Next/ByName helpers.
+    <name>.go                   One file per theme. Each exports a single Palette var.
+```
+
+## Architecture Rules
+
+- `game/` has zero UI dependencies. It must never import `tui/`, `theme/`, or `lipgloss`.
+- `tui/` reads game state through accessors (`g.Text()`, `g.Input()`, `g.Errors()`). It never touches game internals directly.
+- All file I/O is centralized in `storage.go`. No file reads/writes anywhere else.
+- `lang/` uses `embed.FS` to bake data files into the binary at compile time. No runtime file system access for content.
+
+## Adding Content
+
+### New Theme
+
+Create `internal/theme/<name>.go`:
+
+```go
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+var MyTheme = Palette{
+    Name:       "mytheme",
+    Background: lipgloss.Color("#1a1a1a"),
+    Foreground: lipgloss.Color("#555555"),
+    Typed:      lipgloss.Color("#ffffff"),
+    Error:      lipgloss.Color("#ff0000"),
+    Cursor:     lipgloss.Color("#ffffff"),
+    Accent:     lipgloss.Color("#00ff00"),
+    Success:    lipgloss.Color("#00ff00"),
+}
+```
+
+Then add `MyTheme` to the `All` slice in `theme.go`.
+
+### New Language
+
+1. Create `internal/lang/data/<language>/` directory.
+2. Add lesson files inside it. Each file is a self-contained code snippet.
+3. Every lesson file must start with a `// Topic: <title>` comment line. The comment prefix depends on the language (`//`, `#`, or `--`).
+4. The code below the comments is what the user types.
+5. Rebuild. The `embed.FS` picks up new files automatically.
+
+### New Word List
+
+Place a `words.txt` inside a language's data directory. One word per line.
+
+## Coding Conventions
+
+- No unnecessary comments. Code should be self-explanatory.
+- No emoji in source code or CLI output.
+- Error handling: return early, don't wrap in else blocks.
+- Naming: short, lowercase Go conventions. No stuttering (`game.GameState` → `game.State`).
+- Keep functions short. If a view function exceeds ~60 lines, extract helpers.
+- Lipgloss styles are created inline where used. No global style variables.
+
+## Data Format
+
+Results are stored in `~/.toofan/results.txt`, one test per line:
+
+```
+2026-04-01 22:18 |  85 wpm | 97.5% | 30s | words | 83 raw | 2 err
+2026-04-01 22:20 |  54 wpm | 91.0% | 15s | code:go | 60 raw | 5 err
+```
+
+Config is stored in `~/.toofan/config.txt` as key=value pairs:
+
+```
+duration=30
+mode=words
+lang=go
+theme=tokyonight
+```
+
+PBs are stored in `~/.toofan/pb.txt`:
+
+```
+words-30=105
+code-15=54
+```
+
+## Do Not
+
+- Do not add external API calls or network requests.
+- Do not add dependencies beyond Bubble Tea and Lipgloss.
+- Do not use AI-generated code snippets for lessons. All lessons are hand-written.
+- Do not modify the data format in `results.txt` or `pb.txt` without updating both `storage.go` and `profile.go` parsers.
+- Do not add global mutable state outside of `theme.Current`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you prefer building manually (requires Go):
 git clone https://github.com/vyrx-dev/toofan.git
 cd toofan
 go build -o toofan .
-sudo mv toofan /usr/local/bin/toofan
+mv toofan ~/.local/bin/
 ```
 
 ## FAQ
@@ -110,11 +110,12 @@ Yes. Everything runs locally and is embedded in the binary. No internet needed.
 
 ## Roadmap
 
+- [x] Curl script installation (macOS & Linux)
+- [x] Proper documentation for AI and contributors
 - [ ] More language support (python, rust, c, typescript, etc.)
 - [ ] Difficulty levels for english words
-- [ ] AUR, Homebrew, Nix, and curl install
+- [ ] AUR, Homebrew, Nix packages
 - [ ] Fix top pane alignment to match bottom panes in profile
-- [ ] Proper documentation for AI and contributors to understand the project
 
 ## Contributing
 
@@ -122,6 +123,8 @@ Yes. Everything runs locally and is embedded in the binary. No internet needed.
 - New languages : Just a folder with lesson files
 - New themes : One Go file with a color palette
 - Bug fixes and UX improvements
+
+If you're using an AI coding assistant, read [`AGENTS.md`](AGENTS.md) first.
 
 ## Dependencies
 

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -36,6 +36,7 @@ func (g *Game) Input() string        { return g.input }
 func (g *Game) Errors() map[int]bool { return g.errors }
 func (g *Game) Started() bool        { return g.started }
 func (g *Game) Duration() int        { return g.duration }
+func (g *Game) Elapsed() time.Duration { return g.elapsed }
 func (g *Game) SetText(s string)     { g.text = normalizeTabs(s) }
 
 func New(duration int, mode string, language string) *Game {

--- a/internal/tui/typing.go
+++ b/internal/tui/typing.go
@@ -139,8 +139,12 @@ func (m model) viewTyping(p theme.Palette) string {
 	var topLine string
 	if m.game.Started() {
 		timeLeft := m.game.TimeLeft()
-		wpm := m.game.Stats().WPM
-		topLine = hi.Render(fmt.Sprintf("%d", timeLeft)) + dim.Render(fmt.Sprintf("   %.0f wpm", wpm))
+		if m.game.Elapsed().Seconds() >= 3 {
+			wpm := m.game.Stats().WPM
+			topLine = hi.Render(fmt.Sprintf("%d", timeLeft)) + dim.Render(fmt.Sprintf("   %.0f wpm", wpm))
+		} else {
+			topLine = hi.Render(fmt.Sprintf("%d", timeLeft))
+		}
 	} else {
 		if m.duration == 0 {
 			topLine = hi.Render("∞")


### PR DESCRIPTION
This pull request focuses on improving project documentation for both human and AI contributors, clarifies installation instructions, and introduces a minor code enhancement for accessing game state. The most important changes are grouped below.

**Documentation improvements:**

* Added a comprehensive `AGENTS.md` file that explains the project architecture, coding conventions, data formats, and guidelines for AI coding assistants and contributors.
* Updated `README.md` to reference `AGENTS.md` for AI coding assistants, and marked documentation tasks as complete in the roadmap. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R113-L117) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R127-R128)
* Improved manual installation instructions in `README.md` to use a user-local binary directory instead of requiring `sudo`.

**Code enhancements:**

* Added a new accessor method `Elapsed()` to the `Game` struct in `game.go`, allowing UI components to read elapsed time without exposing internals.
* Updated the typing view in `typing.go` to display WPM only after 3 seconds have elapsed, reducing noise at the start of a test.