### PR TITLE
fix: align top panes in profile view

### DIFF
--- a/internal/tui/profile.go
+++ b/internal/tui/profile.go
@@ -200,7 +200,7 @@ func (m model) viewProfile(p theme.Palette) string {
 	if m.width > 0 && m.width < 92 {
 		fullWidth = m.width - 6
 	}
-	paneWidth := (fullWidth - 2) / 3 // 2 gaps of 1 char each
+	paneWidth := (fullWidth - 4) / 3 // 2 gaps of 2 char each
 
 	paneStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -358,7 +358,7 @@ func (m model) viewProfile(p theme.Palette) string {
 	bestBox = paneStyle.Width(paneWidth).Height(maxH - 2).Render(bests)
 	ranksBox = paneStyle.Width(paneWidth).Height(maxH - 2).Render(ranks)
 
-	topRow := lipgloss.JoinHorizontal(lipgloss.Top, overviewBox, " ", bestBox, " ", ranksBox)
+	topRow := lipgloss.JoinHorizontal(lipgloss.Top, overviewBox, "  ", bestBox, "  ", ranksBox)
 
 	var histRows []string
 	header := lipgloss.JoinHorizontal(lipgloss.Left,


### PR DESCRIPTION
Fixed alignment of top section panes (overview, personal bests, ranks) in profile view.

## Changes
- Updated paneWidth calculation from (fullWidth - 2) / 3 to (fullWidth - 4) / 3
- Added extra spacing between panes in topRow join
- Fixed top-section misalignment in the profile view.

## Checklist
- [x] Code follows project guidelines
- [x] PR title is descriptive