### PR TITLE
fix: resolve coding mode typing bugs (#45)

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -106,10 +106,14 @@ func (g *Game) TypeChar(ch rune) {
 	}
 
 	if g.CodeMode {
-		if ch == '\n' && g.text[pos] != '\n' {
-			return
-		}
-		if g.text[pos] == '\n' && ch != '\n' {
+		if g.text[pos] == '\n' {
+			if ch == ' ' {
+				ch = '\n' // allow space to act as enter at the end of a line
+			}
+			if ch != '\n' {
+				return // strict newline enforcement
+			}
+		} else if ch == '\n' {
 			return
 		}
 	}

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -148,6 +148,9 @@ func (g *Game) Backspace() {
 	for len(g.input) > 0 {
 		last := g.input[len(g.input)-1]
 		if last == '\n' {
+			if g.CodeMode {
+				break
+			}
 			g.input = g.input[:len(g.input)-1]
 		} else if last == ' ' && isStartOfLine(g.input[:len(g.input)-1]) {
 			g.input = g.input[:len(g.input)-1]

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -105,8 +105,13 @@ func (g *Game) TypeChar(ch rune) {
 		return
 	}
 
-	if g.CodeMode && ch == '\n' && g.text[pos] != '\n' {
-		return
+	if g.CodeMode {
+		if ch == '\n' && g.text[pos] != '\n' {
+			return
+		}
+		if g.text[pos] == '\n' && ch != '\n' {
+			return
+		}
 	}
 
 	g.input += string(ch)

--- a/internal/tui/typing.go
+++ b/internal/tui/typing.go
@@ -78,11 +78,18 @@ func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-	case "ctrl+h", "?":
+	case "ctrl+h":
 		if !m.game.Started() {
 			m.showHelp = true
 			return m, nil
 		}
+
+	case "?":
+		if !m.game.Started() {
+			m.showHelp = true
+			return m, nil
+		}
+		m.game.TypeChar('?')
 
 	case "ctrl+p":
 		if !m.game.Started() {
@@ -98,8 +105,8 @@ func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.game.Backspace()
 
 	default:
-		if len(msg.Runes) > 0 {
-			m.game.TypeChar(msg.Runes[0])
+		for _, r := range msg.Runes {
+			m.game.TypeChar(r)
 		}
 	}
 


### PR DESCRIPTION
Fixes #45.

This PR addresses three core issues when typing in Code Mode:
1. **Help Keybind Collision:** Separated the `?` character from the `ctrl+h` help menu trigger so `?` can be typed naturally during tests.
2. **Offset Cascades:** Enforced strict newline typing. You can no longer accidentally skip a blank line (causing an offset that turns the rest of the text red).
3. **Aggressive Backspacing:** Backspacing over manually typed newlines in code mode will no longer delete the character preceding the newline.