### PR TITLE
feat: add ghost pacer (pace caret)

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -25,6 +25,7 @@ type Game struct {
 	duration  int
 	CodeMode  bool // true = snippet-based typing, false = standard words
 	difficulty string
+	GhostPos   int
 
 	elapsed   time.Duration
 	lastTyped time.Time
@@ -38,7 +39,16 @@ func (g *Game) Errors() map[int]bool { return g.errors }
 func (g *Game) Started() bool        { return g.started }
 func (g *Game) Duration() int        { return g.duration }
 func (g *Game) Elapsed() time.Duration { return g.elapsed }
+func (g *Game) GhostPosition() int   { return g.GhostPos }
 func (g *Game) SetText(s string)     { g.text = normalizeTabs(s) }
+
+func (g *Game) UpdateGhost(pbWPM float64) {
+	if !g.started || pbWPM <= 0 {
+		return
+	}
+	elapsed := g.elapsed.Seconds()
+	g.GhostPos = int((pbWPM * 5.0 * elapsed) / 60.0)
+}
 
 func New(duration int, mode string, language string, difficulty string) *Game {
 	g := &Game{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -64,11 +64,12 @@ func New() model {
 	theme.Current = theme.ByName(th)
 
 	return model{
-		game:     game.New(duration, mode, language, difficulty),
-		duration: duration,
-		mode:     mode,
-		lang:     language,
+		game:       game.New(duration, mode, language, difficulty),
+		duration:   duration,
+		mode:       mode,
+		lang:       language,
 		difficulty: difficulty,
+		pb:         game.GetPB(duration, mode),
 	}
 }
 
@@ -97,6 +98,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.game.LastTick = time.Time(msg)
 			} else {
 				m.game.Tick(time.Time(msg))
+				m.game.UpdateGhost(m.pb)
 				if m.game.Finished() {
 					m.result = m.game.Stats()
 					m.pb = game.GetPB(m.duration, m.mode)
@@ -190,6 +192,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.duration = durations[m.durCur]
 				m.pickingDur = false
 				m.game = game.New(m.duration, m.mode, m.lang, m.difficulty)
+				m.pb = game.GetPB(m.duration, m.mode)
 				m.save()
 				return m, nil
 			case "esc":

--- a/internal/tui/text.go
+++ b/internal/tui/text.go
@@ -16,6 +16,7 @@ func colorText(g *game.Game, p theme.Palette, lines []string, top, bot int) stri
 	dim := lipgloss.NewStyle().Foreground(p.Foreground)
 
 	typed := len(g.Input())
+	ghost := g.GhostPosition()
 
 	// character offset at top of visible window
 	startPos := 0
@@ -33,16 +34,23 @@ func colorText(g *game.Game, p theme.Palette, lines []string, top, bot int) stri
 		}
 		for _, ch := range lines[i] {
 			s := string(ch)
+			var style lipgloss.Style
 			switch {
 			case pos < typed && g.Errors()[pos]:
-				out.WriteString(bad.Render(s))
+				style = bad
 			case pos < typed:
-				out.WriteString(ok.Render(s))
+				style = ok
 			case pos == typed:
-				out.WriteString(cur.Render(s))
+				style = cur
 			default:
-				out.WriteString(dim.Render(s))
+				style = dim
 			}
+
+			if pos == ghost && pos != typed {
+				style = style.Copy().Underline(true)
+			}
+
+			out.WriteString(style.Render(s))
 			pos++
 		}
 	}

--- a/internal/tui/typing.go
+++ b/internal/tui/typing.go
@@ -46,6 +46,7 @@ func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.mode = "words"
 			}
 			m.game = game.New(m.duration, m.mode, m.lang, m.difficulty)
+			m.pb = game.GetPB(m.duration, m.mode)
 			m.save()
 		}
 


### PR DESCRIPTION
Adds a ghost pacer (pace caret) that shows expected typing position based on PB WPM.

* Computes position using elapsed time and PB WPM
* Updates in game loop
* Renders as subtle underline

Closes #40 