### PR TITLE
issue/fix-51: map `tab` to rrestart tests and `esc` to configure time

### DIFF
--- a/internal/tui/results.go
+++ b/internal/tui/results.go
@@ -24,8 +24,7 @@ func (m model) handleResults(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	case "tab":
-		m.duration = nextDur(m.duration)
-		m.save()
+		// restart immediately after a finished test
 	case "ctrl+t":
 		theme.Next()
 		m.save()
@@ -34,6 +33,15 @@ func (m model) handleResults(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.showingErrors = false
 			return m, nil
 		}
+		m.pickingDur = true
+		m.durCur = 0
+		for i, d := range durations {
+			if d == m.duration {
+				m.durCur = i
+			}
+		}
+		m.active = screenTyping
+		return m, nil
 	}
 
 	if m.showingErrors {

--- a/internal/tui/typing.go
+++ b/internal/tui/typing.go
@@ -14,9 +14,6 @@ import (
 func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
-		m.game.Reset(m.mode, m.lang, m.difficulty)
-
-	case "tab":
 		m.pickingDur = true
 		m.durCur = 0
 		for i, d := range durations {
@@ -25,6 +22,9 @@ func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+
+	case "tab":
+		m.game.Reset(m.mode, m.lang, m.difficulty)
 
 	case "ctrl+d":
 		if m.mode == "words" {
@@ -237,8 +237,8 @@ func (m model) viewHelp(p theme.Palette) string {
 		val.Render("ctrl+t") + dim.Render("    change theme"),
 		val.Render("ctrl+p") + dim.Render("    open profile"),
 		val.Render("ctrl+d") + dim.Render("    change difficulty (words mode only)"),
-		val.Render("tab") + dim.Render("       change duration & restart"),
-		val.Render("esc") + dim.Render("       restart test immediately"),
+		val.Render("tab") + dim.Render("       restart test"),
+		val.Render("esc") + dim.Render("       configure duration"),
 		val.Render("e") + dim.Render("         view error words (results screen)"),
 		val.Render("?") + dim.Render("         show this help"),
 		"",


### PR DESCRIPTION
# resolve issue 51

This PR aims to resolve #51. In the latter concerned issue, the issue creator was concerned that most of toofan users come from monkeytype userbase, and they are used to pressing `tab` for restarting the test. This is a valid point, since users' muscle memory is set and changing muscle memory are usually not preferred.

## What's changed

The help section of the TUI has been updated to reflect `esc` for configuring time, and `tab` for restarting the test. The above listed changes were correctly bind to the new keys in the main TUI code. 

## Notes

* This is a very small change concerning #51.
* Very minor and safe changes were made to the code, and this PR can be merged soon.

