### PR TITLE
issue/fix: (#51) consolidate storage 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ Results are stored in `~/.config/toofan/results.jsonl` (JSON Lines, one test per
 
 Races are stored in `~/.config/toofan/races.jsonl` (JSON Lines, capped at the latest 10 records).
 
-On first run after this format change, old `config.txt`/`pb.txt`/`results.txt`/`races.txt` files are auto-migrated if new files do not exist. Old files are not deleted automatically.
+On first run after this format change, old `config.txt`/`pb.txt`/`results.txt`/`races.txt` files are auto-migrated to the new format and removed after successful conversion.
 
 ## Do Not
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ go run .               # run without building
 go vet ./...           # lint check before committing
 ```
 
-There are no external services, databases, or network calls. User data lives in `~/.config/toofan/` as plain text files.
+There are no external services, databases, or network calls. User data lives in `~/.config/toofan/` as local JSON/JSONL files.
 
 ## Project Structure
 
@@ -96,33 +96,37 @@ Place a `words.txt` inside a language's data directory. One word per line.
 
 ## Data Format
 
-Results are stored in `~/.config/toofan/results.txt`, one test per line:
+Config and PBs are stored together in `~/.config/toofan/config.json`:
 
 ```
-2026-04-01 22:18 |  85 wpm | 97.5% | 30s | words | 83 raw | 2 err
-2026-04-01 22:20 |  54 wpm | 91.0% | 15s | code:go | 60 raw | 5 err
+{
+  "duration": 30,
+  "mode": "words",
+  "lang": "go",
+  "difficulty": "easy",
+  "theme": "tokyonight",
+  "pb": {
+    "words-30": 105,
+    "code-15": 54
+  }
+}
 ```
 
-Config is stored in `~/.config/toofan/config.txt` as key=value pairs:
+Results are stored in `~/.config/toofan/results.jsonl` (JSON Lines, one test per line):
 
 ```
-duration=30
-mode=words
-lang=go
-theme=tokyonight
+{"at":"2026-04-01 22:18","wpm":85,"acc":97.5,"dur":30,"mode":"words","raw":83,"err":2}
+{"at":"2026-04-01 22:20","wpm":54,"acc":91.0,"dur":15,"mode":"code:go","raw":60,"err":5}
 ```
 
-PBs are stored in `~/.config/toofan/pb.txt`:
+Races are stored in `~/.config/toofan/races.jsonl` (JSON Lines, capped at the latest 10 records).
 
-```
-words-30=105
-code-15=54
-```
+On first run after this format change, old `config.txt`/`pb.txt`/`results.txt`/`races.txt` files are auto-migrated if new files do not exist. Old files are not deleted automatically.
 
 ## Do Not
 
 - Do not add external API calls or network requests.
 - Do not add dependencies beyond Bubble Tea and Lipgloss.
 - Do not use AI-generated code snippets for lessons. All lessons are hand-written.
-- Do not modify the data format in `results.txt` or `pb.txt` without updating both `storage.go` and `profile.go` parsers.
+- Do not modify JSON/JSONL data formats without updating both `storage.go` and `profile.go` parsers/readers.
 - Do not add global mutable state outside of `theme.Current`.

--- a/internal/game/storage.go
+++ b/internal/game/storage.go
@@ -25,20 +25,34 @@ type RaceRecord struct {
 	Points     []RacePoint `json:"points"`
 }
 
+type ConfigRecord struct {
+	Duration   int                `json:"duration"`
+	Mode       string             `json:"mode"`
+	Lang       string             `json:"lang"`
+	Difficulty string             `json:"difficulty"`
+	Theme      string             `json:"theme"`
+	PB         map[string]float64 `json:"pb"`
+}
+
+type ResultRecord struct {
+	At   string  `json:"at"`
+	WPM  float64 `json:"wpm"`
+	Acc  float64 `json:"acc"`
+	Dur  int     `json:"dur"`
+	Mode string  `json:"mode"`
+	Raw  float64 `json:"raw"`
+	Err  int     `json:"err"`
+}
+
 func init() {
 	configDir, _ := os.UserConfigDir()
 	dataDir = filepath.Join(configDir, "toofan")
+	migrate()
 }
 
-// SaveResult appends a line to results.txt — human readable
-// format: 2026-04-01 22:18 |  85 wpm | 97.5% | 30s | words | tokyonight
 func SaveResult(s Stats, duration int, mode string, language string) {
 	os.MkdirAll(dataDir, 0755)
-
-	f, err := os.OpenFile(
-		filepath.Join(dataDir, "results.txt"),
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644,
-	)
+	f, err := os.OpenFile(filepath.Join(dataDir, "results.jsonl"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return
 	}
@@ -49,73 +63,42 @@ func SaveResult(s Stats, duration int, mode string, language string) {
 		label = "code:" + language
 	}
 
-	fmt.Fprintf(f, "%s | %3.0f wpm | %5.1f%% | %3ds | %s | %3.0f raw | %d err\n",
-		time.Now().Format("2006-01-02 15:04"),
-		s.WPM, s.Accuracy, duration, label, s.Raw, s.Mistakes,
-	)
-}
-
-func GetPB(duration int, mode string) float64 {
-	path := filepath.Join(dataDir, "pb.txt")
-	f, err := os.Open(path)
-	if err != nil {
-		return 0
+	rec := ResultRecord{
+		At:   time.Now().Format("2006-01-02 15:04"),
+		WPM:  s.WPM,
+		Acc:  s.Accuracy,
+		Dur:  duration,
+		Mode: label,
+		Raw:  s.Raw,
+		Err:  s.Mistakes,
 	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		parts := strings.SplitN(scanner.Text(), "=", 2)
-		if len(parts) == 2 {
-			key := parts[0]
-			val, _ := strconv.ParseFloat(parts[1], 64)
-
-			kp := strings.SplitN(key, "-", 2)
-			if len(kp) == 2 && kp[0] == mode {
-				dur, _ := strconv.Atoi(kp[1])
-				if dur == duration {
-					return val
-				}
-			}
-		}
-	}
-	return 0
-}
-
-func SavePB(duration int, mode string, wpm float64) {
-	os.MkdirAll(dataDir, 0755)
-	path := filepath.Join(dataDir, "pb.txt")
-
-	pbs := make(map[string]float64)
-	if f, err := os.Open(path); err == nil {
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			parts := strings.SplitN(scanner.Text(), "=", 2)
-			if len(parts) == 2 {
-				val, _ := strconv.ParseFloat(parts[1], 64)
-				pbs[parts[0]] = val
-			}
-		}
-		f.Close()
-	}
-
-	key := fmt.Sprintf("%s-%d", mode, duration)
-	pbs[key] = wpm
-
-	f, err := os.Create(path)
+	b, err := json.Marshal(rec)
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	fmt.Fprintln(f, string(b))
+}
 
-	for k, val := range pbs {
-		fmt.Fprintf(f, "%s=%.0f\n", k, val)
+func GetPB(duration int, mode string) float64 {
+	cfg, ok := loadConfigRecord()
+	if !ok || cfg.PB == nil {
+		return 0
 	}
+	return cfg.PB[fmt.Sprintf("%s-%d", mode, duration)]
+}
+
+func SavePB(duration int, mode string, wpm float64) {
+	cfg, _ := loadConfigRecord()
+	if cfg.PB == nil {
+		cfg.PB = make(map[string]float64)
+	}
+	cfg.PB[fmt.Sprintf("%s-%d", mode, duration)] = wpm
+	saveConfigRecord(cfg)
 }
 
 func SaveRace(r RaceRecord) {
 	os.MkdirAll(dataDir, 0755)
-	path := filepath.Join(dataDir, "races.txt")
+	path := filepath.Join(dataDir, "races.jsonl")
 
 	races := LoadRaces()
 	races = append(races, r)
@@ -139,7 +122,7 @@ func SaveRace(r RaceRecord) {
 }
 
 func LoadRaces() []RaceRecord {
-	path := filepath.Join(dataDir, "races.txt")
+	path := filepath.Join(dataDir, "races.jsonl")
 	f, err := os.Open(path)
 	if err != nil {
 		return nil
@@ -164,49 +147,38 @@ func LoadRaces() []RaceRecord {
 	return out
 }
 
-
 func LoadConfig() (duration int, mode string, language string, difficulty string, themeName string) {
 	duration, mode, language, difficulty, themeName = 30, "words", "go", "easy", "tokyonight"
-
-	path := filepath.Join(dataDir, "config.txt")
-	f, err := os.Open(path)
-	if err != nil {
+	cfg, ok := loadConfigRecord()
+	if !ok {
 		return
 	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		parts := strings.SplitN(scanner.Text(), "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		switch parts[0] {
-		case "duration":
-			duration, _ = strconv.Atoi(parts[1])
-		case "mode":
-			mode = parts[1]
-		case "lang":
-			language = parts[1]
-		case "difficulty":
-			difficulty = parts[1]
-		case "theme":
-			themeName = parts[1]
-		}
+	if cfg.Duration > 0 {
+		duration = cfg.Duration
+	}
+	if cfg.Mode != "" {
+		mode = cfg.Mode
+	}
+	if cfg.Lang != "" {
+		language = cfg.Lang
+	}
+	if cfg.Difficulty != "" {
+		difficulty = cfg.Difficulty
+	}
+	if cfg.Theme != "" {
+		themeName = cfg.Theme
 	}
 	return
 }
 
 func SaveConfig(duration int, mode string, language string, difficulty string, themeName string) {
-	os.MkdirAll(dataDir, 0755)
-	f, err := os.Create(filepath.Join(dataDir, "config.txt"))
-	if err != nil {
-		return
-	}
-	defer f.Close()
-
-	fmt.Fprintf(f, "duration=%d\nmode=%s\nlang=%s\ndifficulty=%s\ntheme=%s\n",
-		duration, mode, language, difficulty, themeName)
+	cfg, _ := loadConfigRecord()
+	cfg.Duration = duration
+	cfg.Mode = mode
+	cfg.Lang = language
+	cfg.Difficulty = difficulty
+	cfg.Theme = themeName
+	saveConfigRecord(cfg)
 }
 
 // SplitBundle parses a bundled backup file (sections marked with "### filename")
@@ -241,7 +213,7 @@ func SaveBackup() (string, error) {
 	dest := filepath.Join(backupDir, fmt.Sprintf("toofan_backup_%s.txt", stamp))
 
 	var bundle strings.Builder
-	for _, name := range []string{"results.txt", "pb.txt", "config.txt", "races.txt"} {
+	for _, name := range []string{"config.json", "results.jsonl", "races.jsonl"} {
 		data, err := os.ReadFile(filepath.Join(dataDir, name))
 		if err != nil {
 			continue
@@ -254,6 +226,199 @@ func SaveBackup() (string, error) {
 		return "", err
 	}
 	return dest, nil
+}
+
+func loadConfigRecord() (ConfigRecord, bool) {
+	cfg := ConfigRecord{
+		Duration:   30,
+		Mode:       "words",
+		Lang:       "go",
+		Difficulty: "easy",
+		Theme:      "tokyonight",
+		PB:         make(map[string]float64),
+	}
+	data, err := os.ReadFile(filepath.Join(dataDir, "config.json"))
+	if err != nil {
+		return cfg, false
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return cfg, false
+	}
+	if cfg.PB == nil {
+		cfg.PB = make(map[string]float64)
+	}
+	return cfg, true
+}
+
+func saveConfigRecord(cfg ConfigRecord) {
+	os.MkdirAll(dataDir, 0755)
+	if cfg.PB == nil {
+		cfg.PB = make(map[string]float64)
+	}
+	b, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(filepath.Join(dataDir, "config.json"), b, 0644)
+}
+
+func migrate() {
+	_ = os.MkdirAll(dataDir, 0755)
+	migrateConfig()
+	migrateResults()
+	migrateRaces()
+}
+
+func migrateConfig() {
+	oldConfig := filepath.Join(dataDir, "config.txt")
+	newConfig := filepath.Join(dataDir, "config.json")
+	if !fileExists(oldConfig) || fileExists(newConfig) {
+		return
+	}
+
+	cfg := ConfigRecord{
+		Duration:   30,
+		Mode:       "words",
+		Lang:       "go",
+		Difficulty: "easy",
+		Theme:      "tokyonight",
+		PB:         make(map[string]float64),
+	}
+
+	if f, err := os.Open(oldConfig); err == nil {
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			parts := strings.SplitN(scanner.Text(), "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			switch parts[0] {
+			case "duration":
+				cfg.Duration, _ = strconv.Atoi(parts[1])
+			case "mode":
+				cfg.Mode = parts[1]
+			case "lang":
+				cfg.Lang = parts[1]
+			case "difficulty":
+				cfg.Difficulty = parts[1]
+			case "theme":
+				cfg.Theme = parts[1]
+			}
+		}
+		_ = f.Close()
+	}
+
+	oldPB := filepath.Join(dataDir, "pb.txt")
+	if f, err := os.Open(oldPB); err == nil {
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			parts := strings.SplitN(scanner.Text(), "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			val, err := strconv.ParseFloat(parts[1], 64)
+			if err != nil {
+				continue
+			}
+			cfg.PB[parts[0]] = val
+		}
+		_ = f.Close()
+	}
+
+	saveConfigRecord(cfg)
+	fmt.Printf("migrated config to %s\n", newConfig)
+}
+
+func migrateResults() {
+	oldResults := filepath.Join(dataDir, "results.txt")
+	newResults := filepath.Join(dataDir, "results.jsonl")
+	if !fileExists(oldResults) || fileExists(newResults) {
+		return
+	}
+
+	in, err := os.Open(oldResults)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+
+	out, err := os.Create(newResults)
+	if err != nil {
+		return
+	}
+	defer out.Close()
+
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		rec, ok := parseLegacyResultLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		b, err := json.Marshal(rec)
+		if err != nil {
+			continue
+		}
+		fmt.Fprintln(out, string(b))
+	}
+	fmt.Printf("migrated results to %s\n", newResults)
+}
+
+func migrateRaces() {
+	oldRaces := filepath.Join(dataDir, "races.txt")
+	newRaces := filepath.Join(dataDir, "races.jsonl")
+	if !fileExists(oldRaces) || fileExists(newRaces) {
+		return
+	}
+	if err := os.Rename(oldRaces, newRaces); err != nil {
+		return
+	}
+	fmt.Printf("migrated races to %s\n", newRaces)
+}
+
+func parseLegacyResultLine(line string) (ResultRecord, bool) {
+	parts := strings.Split(line, "|")
+	if len(parts) < 5 {
+		return ResultRecord{}, false
+	}
+
+	rec := ResultRecord{
+		At:   strings.TrimSpace(parts[0]),
+		Mode: strings.TrimSpace(parts[4]),
+	}
+	var err error
+
+	wpmStr := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(parts[1]), "wpm"))
+	rec.WPM, err = strconv.ParseFloat(wpmStr, 64)
+	if err != nil {
+		return ResultRecord{}, false
+	}
+
+	accStr := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(parts[2]), "%"))
+	rec.Acc, err = strconv.ParseFloat(accStr, 64)
+	if err != nil {
+		return ResultRecord{}, false
+	}
+
+	durStr := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(parts[3]), "s"))
+	rec.Dur, err = strconv.Atoi(durStr)
+	if err != nil {
+		return ResultRecord{}, false
+	}
+
+	if len(parts) >= 6 {
+		rawStr := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(parts[5]), "raw"))
+		rec.Raw, _ = strconv.ParseFloat(rawStr, 64)
+	}
+	if len(parts) >= 7 {
+		errStr := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(parts[6]), "err"))
+		rec.Err, _ = strconv.Atoi(errStr)
+	}
+	return rec, true
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func RestoreBackup(src string) error {

--- a/internal/game/storage.go
+++ b/internal/game/storage.go
@@ -210,7 +210,7 @@ func SaveBackup() (string, error) {
 	os.MkdirAll(backupDir, 0755)
 
 	stamp := time.Now().Format("2006-01-02_15-04")
-	dest := filepath.Join(backupDir, fmt.Sprintf("toofan_backup_%s.txt", stamp))
+	dest := filepath.Join(backupDir, fmt.Sprintf("toofan_backup_%s.bak", stamp))
 
 	var bundle strings.Builder
 	for _, name := range []string{"config.json", "results.jsonl", "races.jsonl"} {
@@ -267,112 +267,199 @@ func migrate() {
 	migrateConfig()
 	migrateResults()
 	migrateRaces()
+	migrateBackups()
 }
 
 func migrateConfig() {
 	oldConfig := filepath.Join(dataDir, "config.txt")
+	oldPB := filepath.Join(dataDir, "pb.txt")
 	newConfig := filepath.Join(dataDir, "config.json")
-	if !fileExists(oldConfig) || fileExists(newConfig) {
+
+	if !fileExists(oldConfig) && !fileExists(oldPB) {
 		return
 	}
 
-	cfg := ConfigRecord{
-		Duration:   30,
-		Mode:       "words",
-		Lang:       "go",
-		Difficulty: "easy",
-		Theme:      "tokyonight",
-		PB:         make(map[string]float64),
-	}
-
-	if f, err := os.Open(oldConfig); err == nil {
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			parts := strings.SplitN(scanner.Text(), "=", 2)
-			if len(parts) != 2 {
-				continue
-			}
-			switch parts[0] {
-			case "duration":
-				cfg.Duration, _ = strconv.Atoi(parts[1])
-			case "mode":
-				cfg.Mode = parts[1]
-			case "lang":
-				cfg.Lang = parts[1]
-			case "difficulty":
-				cfg.Difficulty = parts[1]
-			case "theme":
-				cfg.Theme = parts[1]
-			}
+	if !fileExists(newConfig) {
+		cfg := ConfigRecord{
+			Duration:   30,
+			Mode:       "words",
+			Lang:       "go",
+			Difficulty: "easy",
+			Theme:      "tokyonight",
+			PB:         make(map[string]float64),
 		}
-		_ = f.Close()
-	}
 
-	oldPB := filepath.Join(dataDir, "pb.txt")
-	if f, err := os.Open(oldPB); err == nil {
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			parts := strings.SplitN(scanner.Text(), "=", 2)
-			if len(parts) != 2 {
-				continue
+		if f, err := os.Open(oldConfig); err == nil {
+			scanner := bufio.NewScanner(f)
+			for scanner.Scan() {
+				parts := strings.SplitN(scanner.Text(), "=", 2)
+				if len(parts) != 2 {
+					continue
+				}
+				switch parts[0] {
+				case "duration":
+					cfg.Duration, _ = strconv.Atoi(parts[1])
+				case "mode":
+					cfg.Mode = parts[1]
+				case "lang":
+					cfg.Lang = parts[1]
+				case "difficulty":
+					cfg.Difficulty = parts[1]
+				case "theme":
+					cfg.Theme = parts[1]
+				}
 			}
-			val, err := strconv.ParseFloat(parts[1], 64)
-			if err != nil {
-				continue
-			}
-			cfg.PB[parts[0]] = val
+			_ = f.Close()
 		}
-		_ = f.Close()
+
+		if f, err := os.Open(oldPB); err == nil {
+			scanner := bufio.NewScanner(f)
+			for scanner.Scan() {
+				parts := strings.SplitN(scanner.Text(), "=", 2)
+				if len(parts) != 2 {
+					continue
+				}
+				val, err := strconv.ParseFloat(parts[1], 64)
+				if err != nil {
+					continue
+				}
+				cfg.PB[parts[0]] = val
+			}
+			_ = f.Close()
+		}
+
+		saveConfigRecord(cfg)
+		if !fileExists(newConfig) {
+			return
+		}
+		fmt.Printf("migrated config to %s\n", newConfig)
 	}
 
-	saveConfigRecord(cfg)
-	fmt.Printf("migrated config to %s\n", newConfig)
+	_ = os.Remove(oldConfig)
+	_ = os.Remove(oldPB)
 }
 
 func migrateResults() {
 	oldResults := filepath.Join(dataDir, "results.txt")
 	newResults := filepath.Join(dataDir, "results.jsonl")
-	if !fileExists(oldResults) || fileExists(newResults) {
+
+	if !fileExists(oldResults) {
 		return
 	}
 
-	in, err := os.Open(oldResults)
-	if err != nil {
-		return
-	}
-	defer in.Close()
-
-	out, err := os.Create(newResults)
-	if err != nil {
-		return
-	}
-	defer out.Close()
-
-	scanner := bufio.NewScanner(in)
-	for scanner.Scan() {
-		rec, ok := parseLegacyResultLine(scanner.Text())
-		if !ok {
-			continue
-		}
-		b, err := json.Marshal(rec)
+	if !fileExists(newResults) {
+		in, err := os.Open(oldResults)
 		if err != nil {
-			continue
+			return
 		}
-		fmt.Fprintln(out, string(b))
+
+		out, err := os.Create(newResults)
+		if err != nil {
+			in.Close()
+			return
+		}
+
+		scanner := bufio.NewScanner(in)
+		for scanner.Scan() {
+			rec, ok := parseLegacyResultLine(scanner.Text())
+			if !ok {
+				continue
+			}
+			b, err := json.Marshal(rec)
+			if err != nil {
+				continue
+			}
+			fmt.Fprintln(out, string(b))
+		}
+		in.Close()
+		out.Close()
+
+		if !fileExists(newResults) {
+			return
+		}
+		fmt.Printf("migrated results to %s\n", newResults)
 	}
-	fmt.Printf("migrated results to %s\n", newResults)
+
+	_ = os.Remove(oldResults)
 }
 
 func migrateRaces() {
 	oldRaces := filepath.Join(dataDir, "races.txt")
 	newRaces := filepath.Join(dataDir, "races.jsonl")
-	if !fileExists(oldRaces) || fileExists(newRaces) {
+
+	if !fileExists(oldRaces) {
 		return
 	}
-	if err := os.Rename(oldRaces, newRaces); err != nil {
-		return
+
+	if !fileExists(newRaces) {
+		data, err := os.ReadFile(oldRaces)
+		if err != nil {
+			return
+		}
+		if err := os.WriteFile(newRaces, data, 0644); err != nil {
+			return
+		}
+		fmt.Printf("migrated races to %s\n", newRaces)
 	}
-	fmt.Printf("migrated races to %s\n", newRaces)
+
+	_ = os.Remove(oldRaces)
+}
+
+func migrateBackups() {
+	backupDir := filepath.Join(dataDir, "backups")
+
+	txt, _ := filepath.Glob(filepath.Join(backupDir, "toofan_backup_*.txt"))
+	for _, src := range txt {
+		dest := strings.TrimSuffix(src, ".txt") + ".bak"
+		if !fileExists(dest) {
+			_ = os.Rename(src, dest)
+		} else {
+			_ = os.Remove(src)
+		}
+	}
+
+	jsonl, _ := filepath.Glob(filepath.Join(backupDir, "toofan_backup_*.jsonl"))
+	for _, src := range jsonl {
+		raw, err := os.ReadFile(src)
+		if err != nil {
+			continue
+		}
+		dest := strings.TrimSuffix(src, ".jsonl") + ".bak"
+		if fileExists(dest) {
+			_ = os.Remove(src)
+			continue
+		}
+
+		content := string(raw)
+		if strings.HasPrefix(strings.TrimSpace(content), "{") {
+			var bundle strings.Builder
+			for _, line := range strings.Split(content, "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" {
+					continue
+				}
+				var entry struct {
+					File string `json:"file"`
+					Data string `json:"data"`
+				}
+				if json.Unmarshal([]byte(line), &entry) != nil {
+					continue
+				}
+				bundle.WriteString("### " + entry.File + "\n")
+				bundle.WriteString(entry.Data)
+				if !strings.HasSuffix(entry.Data, "\n") {
+					bundle.WriteString("\n")
+				}
+			}
+			_ = os.WriteFile(dest, []byte(bundle.String()), 0644)
+		} else {
+			_ = os.WriteFile(dest, raw, 0644)
+		}
+
+		if fileExists(dest) {
+			_ = os.Remove(src)
+		}
+	}
 }
 
 func parseLegacyResultLine(line string) (ResultRecord, bool) {
@@ -427,14 +514,14 @@ func RestoreBackup(src string) error {
 		return err
 	}
 	for name, data := range SplitBundle(string(raw)) {
-		os.WriteFile(filepath.Join(dataDir, name), []byte(data), 0644)
+		_ = os.WriteFile(filepath.Join(dataDir, name), []byte(data), 0644)
 	}
 	return nil
 }
 
 func ListBackups() ([]string, string) {
 	backupDir := filepath.Join(dataDir, "backups")
-	files, _ := filepath.Glob(filepath.Join(backupDir, "toofan_backup_*.txt"))
+	files, _ := filepath.Glob(filepath.Join(backupDir, "toofan_backup_*.bak"))
 	for i, j := 0, len(files)-1; i < j; i, j = i+1, j-1 {
 		files[i], files[j] = files[j], files[i]
 	}

--- a/internal/game/storage.go
+++ b/internal/game/storage.go
@@ -45,7 +45,10 @@ type ResultRecord struct {
 }
 
 func init() {
-	configDir, _ := os.UserConfigDir()
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return
+	}
 	dataDir = filepath.Join(configDir, "toofan")
 	migrate()
 }

--- a/internal/tui/profile.go
+++ b/internal/tui/profile.go
@@ -2,15 +2,16 @@ package tui
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/vyrx-dev/toofan/internal/game"
 	"github.com/vyrx-dev/toofan/internal/theme"
 )
 
@@ -48,7 +49,7 @@ func loadProfile() profileData {
 	}
 	dataDir := filepath.Join(configDir, "toofan")
 
-	f, err := os.Open(filepath.Join(dataDir, "results.txt"))
+	f, err := os.Open(filepath.Join(dataDir, "results.jsonl"))
 	if err != nil {
 		return pd
 	}
@@ -117,49 +118,25 @@ func avgWPM(tests []testEntry) float64 {
 }
 
 func parseResultLine(line string) (testEntry, bool) {
-	parts := strings.Split(line, "|")
-	if len(parts) < 5 {
+	var rec game.ResultRecord
+	if err := json.Unmarshal([]byte(line), &rec); err != nil {
 		return testEntry{}, false
 	}
 
-	date, err := time.Parse("2006-01-02 15:04", strings.TrimSpace(parts[0]))
+	date, err := time.Parse("2006-01-02 15:04", rec.At)
 	if err != nil {
 		return testEntry{}, false
 	}
 
-	wpmStr := strings.TrimSpace(parts[1])
-	wpmStr = strings.TrimSuffix(wpmStr, "wpm")
-	wpmStr = strings.TrimSpace(wpmStr)
-	wpm, _ := strconv.ParseFloat(wpmStr, 64)
-
-	accStr := strings.TrimSpace(parts[2])
-	accStr = strings.TrimSuffix(accStr, "%")
-	accStr = strings.TrimSpace(accStr)
-	acc, _ := strconv.ParseFloat(accStr, 64)
-
-	durStr := strings.TrimSpace(parts[3])
-	durStr = strings.TrimSuffix(durStr, "s")
-	durStr = strings.TrimSpace(durStr)
-	dur, _ := strconv.Atoi(durStr)
-
-	modeStr := strings.TrimSpace(parts[4])
-
-	var raw float64
-	var errors int
-	if len(parts) >= 6 {
-		rawStr := strings.TrimSpace(parts[5])
-		rawStr = strings.TrimSuffix(rawStr, "raw")
-		rawStr = strings.TrimSpace(rawStr)
-		raw, _ = strconv.ParseFloat(rawStr, 64)
-	}
-	if len(parts) >= 7 {
-		errStr := strings.TrimSpace(parts[6])
-		errStr = strings.TrimSuffix(errStr, "err")
-		errStr = strings.TrimSpace(errStr)
-		errors, _ = strconv.Atoi(errStr)
-	}
-
-	return testEntry{Date: date, WPM: wpm, Dur: dur, Acc: acc, Mode: modeStr, Raw: raw, Errors: errors}, true
+	return testEntry{
+		Date:   date,
+		WPM:    rec.WPM,
+		Dur:    rec.Dur,
+		Acc:    rec.Acc,
+		Mode:   rec.Mode,
+		Raw:    rec.Raw,
+		Errors: rec.Err,
+	}, true
 }
 
 func (m model) handleProfile(msg tea.KeyMsg) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
## Summary
Fixes #55.
Consolidated Toofan user data from 4 mixed-format files to 3 consistent JSON-based files:

- `config.txt` + `pb.txt` -> `config.json`
- `results.txt` -> `results.jsonl`
- `races.txt` -> `races.jsonl` (same JSONL payload, extension/path corrected)

This removes custom string parsing, unifies persistence format, and keeps append-only logs efficient.

## New data layout

```text
~/.config/toofan/
├── config.json
├── results.jsonl
└── races.jsonl