### PR TITLE
feat: add word-delete-keybindings

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -178,7 +178,29 @@ func (g *Game) Backspace() {
 	}
 	g.recordRacePoint()
 }
+func (g *Game) BackspaceWord() {
+	if len(g.input) == 0 {
+		return
+	}
 
+	g.lastTyped = time.Now()
+
+	// Trim trailing spaces first
+	for len(g.input) > 0 && g.input[len(g.input)-1] == ' ' {
+		pos := len(g.input) - 1
+		g.input = g.input[:pos]
+		delete(g.errors, pos)
+	}
+
+	// Then delete until hitting  a space or the beginning
+	for len(g.input) > 0 && g.input[len(g.input)-1] != ' ' {
+		pos := len(g.input) - 1
+		g.input = g.input[:pos]
+		delete(g.errors, pos)
+	}
+
+	g.recordRacePoint()
+}
 func (g *Game) TimeLeft() int {
 	if !g.started {
 		return g.duration

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -178,6 +178,7 @@ func (g *Game) Backspace() {
 	}
 	g.recordRacePoint()
 }
+
 func (g *Game) BackspaceWord() {
 	if len(g.input) == 0 {
 		return
@@ -192,7 +193,7 @@ func (g *Game) BackspaceWord() {
 		delete(g.errors, pos)
 	}
 
-	// Then delete until hitting  a space or the beginning
+	// Then delete until hitting a space or the beginning
 	for len(g.input) > 0 && g.input[len(g.input)-1] != ' ' {
 		pos := len(g.input) - 1
 		g.input = g.input[:pos]
@@ -201,6 +202,7 @@ func (g *Game) BackspaceWord() {
 
 	g.recordRacePoint()
 }
+
 func (g *Game) TimeLeft() int {
 	if !g.started {
 		return g.duration

--- a/internal/tui/typing.go
+++ b/internal/tui/typing.go
@@ -53,6 +53,8 @@ func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			m.game = game.New(m.duration, m.mode, m.lang, m.difficulty)
 			m.save()
+		} else {
+			m.game.BackspaceWord() //added ctrl + w to delete a whole word only when typing begins
 		}
 
 	case "ctrl+l":
@@ -67,6 +69,14 @@ func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		//this is for termux since it reads ctrl + backspace as ctrl + h
+	case "ctrl+h":
+			if m.game.Started() {
+					m.game.BackspaceWord()
+			} else {
+					m.showHelp = true
+					return m, nil
+			}
 	case "ctrl+o":
 		if m.mode == "code" && !m.game.Started() {
 			m.activeRace = nil
@@ -83,11 +93,7 @@ func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-	case "ctrl+h":
-		if !m.game.Started() {
-			m.showHelp = true
-			return m, nil
-		}
+
 
 	case "?":
 		if !m.game.Started() {

--- a/internal/tui/typing.go
+++ b/internal/tui/typing.go
@@ -54,7 +54,7 @@ func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.game = game.New(m.duration, m.mode, m.lang, m.difficulty)
 			m.save()
 		} else {
-			m.game.BackspaceWord() //added ctrl + w to delete a whole word only when typing begins
+			m.game.BackspaceWord()
 		}
 
 	case "ctrl+l":
@@ -69,14 +69,6 @@ func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		//this is for termux since it reads ctrl + backspace as ctrl + h
-	case "ctrl+h":
-			if m.game.Started() {
-					m.game.BackspaceWord()
-			} else {
-					m.showHelp = true
-					return m, nil
-			}
 	case "ctrl+o":
 		if m.mode == "code" && !m.game.Started() {
 			m.activeRace = nil
@@ -93,7 +85,11 @@ func (m model) handleTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-
+	case "ctrl+h":
+		if !m.game.Started() {
+			m.showHelp = true
+			return m, nil
+		}
 
 	case "?":
 		if !m.game.Started() {


### PR DESCRIPTION
adds word-delete support while typing:
ctrl+w deletes the last word during an active test while preserving existing keybind.
if using termux, ctrl+h (ctrl + backspace in termux) also deletes the last word while typing.
