### PR TITLE
build(nix): add flake with package, app, & devShell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # build output
 toofan
 
+## nix
+/result
+
 # editor
 .idea/
 .vscode/
@@ -16,3 +19,6 @@ Thumbs.db
 *.exe
 *.test
 *.out
+
+# devenv
+.direnv/

--- a/README.md
+++ b/README.md
@@ -69,7 +69,42 @@ paru -S toofan-bin
 go install github.com/vyrx-dev/toofan@latest
 ```
 
-### Homebrew / Nix / Ubuntu / Fedora
+### NixOS / Nix
+
+### Try without installing using flake
+
+```bash
+nix run github:vyrx-dev/toofan
+```
+
+### Install using flake
+
+1. Add flake input:
+
+
+```nix
+toofan = {
+  url = "github:vyrx-dev/toofan";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+
+```
+
+2. Add package to `environment.systemPackages` (for global install) or homeManager `home.packages` (for user install):
+
+
+```nix
+environment.systemPackages = [ inputs.toofan.packages.${pkgs.stdenv.hostPlatform.system}.default ];
+
+```
+
+or
+
+```nix
+home.packages = [ inputs.toofan.packages.${pkgs.stdenv.hostPlatform.system}.default ];
+```
+
+### Homebrew / Ubuntu / Fedora
 
 Coming soon.
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "A minimal, lightning-fast typing TUI";
+
+  inputs = {
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } (
+      { ... }: {
+        systems = [
+          "x86_64-linux"
+        ];
+
+        perSystem = { self', pkgs, ... }: {
+          devShells.default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [ go ];
+          };
+
+          packages.default = pkgs.buildGoModule {
+            pname = "toofan";
+            version = "2.4.1";
+            src = ./.;
+
+            vendorHash = "sha256-YSjJ8NOL97hXZLnfGYIjoKmARv+gWOsv+5qkl9konnA=";
+
+            nativeBuildInputs = with pkgs; [ go ];
+
+            # `buildGoModule` was complaining about "inconsistent vendoring".
+            # May need to rerun `go mod vendor` on the upstream repo.
+            # This has nix stip the vendor dir and let's it vendor itself.
+            # This fixes `nix run` and `nix build`.
+            postPatch = ''
+              rm -rf vendor
+            '';
+
+            meta = {
+              description = "A minimal, lightning-fast typing TUI";
+              mainProgram = "toofan";
+            };
+          };
+
+          apps.default = {
+            type = "app";
+            program = "${self'.packages.default}/bin/toofan";
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
I created a nix flake using flake-parts with a package, app, and devShell.

I added .envrc to enable devenv for automatically loading the devShell for those who use it.

I've tested the tool on my local system. I'm running NixOS unstable. I do not have access to a MacOS device, so I did not add "aarch64-darwin" to the `systems` array in `flake.nix`.